### PR TITLE
Added dmenu argument, full PATH, and Debian/etc support

### DIFF
--- a/dmenu-terminal
+++ b/dmenu-terminal
@@ -1,12 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
 # use the terminal emulator passed-in, or fall back to terminal variable, urxvt or xterm if installed
 if [ "$#" -ne 1 ]; then
-  TERMINAL="$1"
+  if [ -x "$(command -v -- "$1")" ]; then
+    TERMINAL="$1"
+	shift
+  fi
 fi
 
 if [ ! -x "$TERMINAL" -a -x "$(command -v urxvt)" ]; then
   TERMINAL="$(command -v urxvt)"
+elif [ -x "$(command -v gnome-terminal)" ]; then
+  TERMINAL="$(command -v gnome-terminal)"
 elif [ -x "$(command -v xterm)" ]; then
   TERMINAL="$(command -v xterm)"
 else
@@ -20,13 +25,13 @@ if [ ! -x "$(command -v dmenu)" ]; then
   exit 69
 fi
 
-#FIXME: search multiple directories
-choice=$(ls /usr/bin | dmenu)
+choice=$(compgen -c | dmenu "$@")
 binary=$(awk '{print $1;}' <<< $choice)
+fullpath=$(command -v $choice)
 
-if [ -x "$(command -v $choice)" ]; then
+if [ -x $fullpath ]; then
   #FIXME: Wayland
-  if ldd /usr/bin/$binary | grep libX11 > /dev/null; then
+  if ldd $fullpath | grep libX11 > /dev/null; then
     $choice
   else
     $TERMINAL -e $choice

--- a/dmenu-terminal
+++ b/dmenu-terminal
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# use the terminal emulator passed-in, or fall back to terminal variable, urxvt or xterm if installed
+# use the terminal emulator passed-in, or fall back
 if [ "$#" -ne 1 ]; then
   if [ -x "$(command -v -- "$1")" ]; then
     TERMINAL="$1"
@@ -8,6 +8,7 @@ if [ "$#" -ne 1 ]; then
   fi
 fi
 
+# fall back to terminal variable, urxvt, gnome-terminal, or xterm if installed
 if [ ! -x "$TERMINAL" -a -x "$(command -v urxvt)" ]; then
   TERMINAL="$(command -v urxvt)"
 elif [ -x "$(command -v gnome-terminal)" ]; then
@@ -27,13 +28,13 @@ fi
 
 choice=$(compgen -c | dmenu "$@")
 binary=$(awk '{print $1;}' <<< $choice)
-fullpath=$(command -v $choice)
+fullpath=$(command -v $binary)
 
 if [ -x $fullpath ]; then
   #FIXME: Wayland
   if ldd $fullpath | grep libX11 > /dev/null; then
     $choice
   else
-    $TERMINAL -e $choice
+    $TERMINAL -e "$choice"
   fi
 fi


### PR DESCRIPTION
Arguments passed on to dmenu-terminal are passed onto dmenu, while still allowing you to pass a terminal (it checks for executable, which will never be passed to dmenu). I wanted this because I use a different font for my dmenu.
Uses compgen -c to list available commands for dmenu. This allows things not in /usr/bin to work. I needed this because, for example I have firefox in /opt/firefox.
Also, the script uses `<<<` which isn't support by `dash` (Debian default) so I changed `#!/bin/sh` to `#!/bin/bash` so it'll work on Debian/-derived systems.
With these changes dmenu-terminal works perfectly for me! So I thought I'd share.
I wanted to submit the pull request to you because you seem to be a bit ahead of losingkeys and have another promising-looking pull request. This is my first pull request, please consider taking it.